### PR TITLE
Add two conditional rules of constructing layers to DNA

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,22 @@ const layerConfigurations = [
       { name: "Shine" },
       { name: "Bottom lid" },
       { name: "Top lid" },
+
+      // { name: "Fur" },
+      // { name: "Hair", 
+      //   options: {
+      //     subGroup: true, // existance of sub folder corresponding to each kind of fur
+      //     linkLayer: 7, // layer 7 of Fur
+      //   },
+      // },
+      // { name: "Hats",  
+      //   options: {
+      //     noneToReveal: ['Hat_type1.png', 'Hat_type2.png'], // list of hats
+      //                                    // revealed only when Hair is None
+      //     linkLayer: 8, // layer 8 of Hair
+      //   },
+      // },  
+
     ],
   },
 ];

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,8 @@ let hashlipsGiffer = null;
 
 const buildSetup = () => {
   if (fs.existsSync(buildDir)) {
-    fs.rmdirSync(buildDir, { recursive: true });
+    // fs.rmdirSync => fs.rmSync due to fs.rmdirSync being degraded
+    fs.rmSync(buildDir, { recursive: true });
   }
   fs.mkdirSync(buildDir);
   fs.mkdirSync(`${buildDir}/json`);
@@ -68,7 +69,11 @@ const cleanName = (_str) => {
   return nameWithoutWeight;
 };
 
-const getElements = (path) => {
+/* get elements for all image files under a path.
+   The elements are put into a flat array.
+   return [{id, name, filename, path, weight}...]
+*/ 
+const getFlatElements = (path) => {
   return fs
     .readdirSync(path)
     .filter((item) => !/(^|\/)\.[^\/\.]/g.test(item))
@@ -86,26 +91,132 @@ const getElements = (path) => {
     });
 };
 
+// get sub folders or file names under a path
+const getSubDirs = (path) => {
+  return fs
+    .readdirSync(path)
+    .filter((item) => !/(^|\/)\.[^\/\.]/g.test(item))
+}
+
+/* get elements for a layer with sub folders.
+   The elements are grouped into an array for the files under each sub folder, 
+   and an object of {group: folder_name, elements: element_array} is created for
+   a sub folder, thus such multiple objects are arrayed together.
+   return [{ group: folder_name, 
+             elements:[{id, name, filename, path, weight}...]}...]
+*/ 
+const getRecursiveElements = (path) => {
+  return getSubDirs(path)
+    .map((obj)=>({
+      group: obj,
+      elements: fs.readdirSync(path+obj)
+      .map((i, index)=> { 
+        return {
+          id: index,
+          name:cleanName(i),
+          filename: i,
+          path: `${path}${obj}/${i}`,
+          weight: getRarityWeight(i),
+        }
+      })
+  }))
+}
+
+/* get elements for a layer where some images are revealed only when a 
+   specified layer's image is None while others revealed else.
+   The elements are grouped in two objects, one has a key named 'noneToReveal'
+   for elements which only reveal when the specified layer's image is None, the
+   other has a key named 'overlapReveal' for elements which reveal when the
+   specified layer's image is not None.
+   return {noneToReveal: [{id, name, filename, path, weight}...], 
+           overlapReveal: [{id, name, filename, path, weight}...]}
+*/ 
+const getNoneToRevealElements = (layerObj) => {
+  // get all files under the layer
+  let allFiles = fs.readdirSync(`${layersDir}/${layerObj.name}/`)
+                    .filter((item) => !/(^|\/)\.[^\/\.]/g.test(item))
+
+  // get noneToRevealFiles/overlapRevealFiles by intersecting/differenting allFiles 
+  // with/from noneToReveal files specified in the layerObj.options.noneToReveal
+  noneToRevealFiles = allFiles.filter( (val) => { return layerObj.options.noneToReveal.indexOf(val) > -1})
+  overlapRevealFiles = allFiles.filter( (val) => { return layerObj.options.noneToReveal.indexOf(val) === -1})
+  
+  // get noneToRevealElements and overlapRevealElements
+  noneToRevealElements =
+    noneToRevealFiles.map((i, index) => ({
+        id: index,
+        name: cleanName(i),
+        filename: i,
+        path: `${layersDir}/${layerObj.name}/${i}`,
+        weight: getRarityWeight(i),
+    }))
+  
+  overlapRevealElements =
+    overlapRevealFiles.map((i, index) => ({
+        id: index,
+        name: cleanName(i),
+        filename: i,
+        path: `${layersDir}/${layerObj.name}/${i}`,
+        weight: getRarityWeight(i),
+    }))
+  
+    // form a object and return
+  return {noneToReveal: noneToRevealElements, overlapReveal:overlapRevealElements}
+}
+
+
+/* get elements (single_element = {id, name, filename, path, weight}) for a layerObj in 
+   three different conditions:
+   1. (layerObj.options?.['subGroup'] == true) => layer has sub folders
+   2. (layerObj.options?.['noneToReveal']?.length > 0) => images are grouped together in
+       different conditons whether a specified other layer image is None or not
+   3. normal contdition: elements are gathered in a flat array [single_element ...]
+*/
+const getElements = (layerObj) => {
+  let elements = 
+    layerObj.options?.['subGroup'] == true 
+      ? getRecursiveElements(`${layersDir}/${layerObj.name}/`)
+      : (layerObj.options?.['noneToReveal']?.length > 0
+          ? getNoneToRevealElements(layerObj)
+          : getFlatElements(`${layersDir}/${layerObj.name}/`)
+      )
+  return elements
+}
+
+// set up layers in a standard way to be used for createDna(), constructDnaLayer() etc.
 const layersSetup = (layersOrder) => {
   const layers = layersOrder.map((layerObj, index) => ({
-    id: index,
-    elements: getElements(`${layersDir}/${layerObj.name}/`),
-    name:
-      layerObj.options?.["displayName"] != undefined
-        ? layerObj.options?.["displayName"]
-        : layerObj.name,
-    blend:
-      layerObj.options?.["blend"] != undefined
-        ? layerObj.options?.["blend"]
-        : "source-over",
-    opacity:
-      layerObj.options?.["opacity"] != undefined
-        ? layerObj.options?.["opacity"]
-        : 1,
-    bypassDNA:
-      layerObj.options?.["bypassDNA"] !== undefined
-        ? layerObj.options?.["bypassDNA"]
+      id: index,
+      elements:
+        getElements(layerObj), //elements may be grouped in three different ways 
+      name:
+        layerObj.options?.["displayName"] != undefined
+          ? layerObj.options?.["displayName"]
+          : layerObj.name,
+      blend:
+        layerObj.options?.["blend"] != undefined
+          ? layerObj.options?.["blend"]
+          : "source-over",
+      opacity:
+        layerObj.options?.["opacity"] != undefined
+          ? layerObj.options?.["opacity"]
+          : 1,
+      bypassDNA:
+        layerObj.options?.["bypassDNA"] !== undefined
+          ? layerObj.options?.["bypassDNA"]
+          : false,
+      subGroup:
+        layerObj.options?.["subGroup"] !== undefined
+        ? layerObj.options?.["subGroup"]
         : false,
+      linkLayer:
+        layerObj.options?.["linkLayer"] !== undefined
+        ? layerObj.options?.["linkLayer"]
+        : -1,
+      noneToReveal:
+        layerObj.options?.["noneToReveal"] !== undefined
+        ? layerObj.options?.["noneToReveal"]
+        : [],
   }));
   return layers;
 };
@@ -221,8 +332,28 @@ const drawElement = (_renderObject, _index, _layersLen) => {
 
 const constructLayerToDna = (_dna = "", _layers = []) => {
   let mappedDnaToLayers = _layers.map((layer, index) => {
-    let selectedElement = layer.elements.find(
-      (e) => e.id == cleanDna(_dna.split(DNA_DELIMITER)[index])
+    /* As elements are grouped in three ways for each different kind of layer as specified in
+       layerConfigurations.layersOrder by the file src/config.js, elements are extracted for
+       each layer in their conresponding ways.
+    */
+    // if the layer has sub_groups, the elements are nested in the sub_group 
+    cur_elements = 
+      layer.subGroup == true
+      ? (layer.elements.find(item => 
+          item.group === cleanName(_dna.split(DNA_DELIMITER)[layer.linkLayer].split(':').pop()))).elements
+      : layer.elements
+    
+    // if some of images of the layer are only revealed when a specified layer image is None,
+    // the elements for these images are grouped in an object.
+    if (layer.noneToReveal.length > 0) {
+      cur_elements = 
+        cleanName(_dna.split(DNA_DELIMITER)[layer.linkLayer].split(':').pop()) === 'None'
+        ? cur_elements['noneToReveal']
+        : cur_elements['overlapReveal']
+    }
+
+    let selectedElement = cur_elements.find(
+          (e) => e.id == cleanDna(_dna.split(DNA_DELIMITER)[index])
     );
     return {
       name: layer.name,
@@ -283,17 +414,35 @@ const createDna = (_layers) => {
   let randNum = [];
   _layers.forEach((layer) => {
     var totalWeight = 0;
-    layer.elements.forEach((element) => {
+    // if the layer has sub_groups, the elements are nested in the sub_group 
+    cur_elements = 
+      layer.subGroup == true
+      ? (layer.elements.find(item => 
+        item.group === cleanName(randNum[layer.linkLayer].split(':').pop()))).elements
+      : layer.elements
+    // if some of images of the layer are only revealed when a specified layer image is None,
+    // the elements are grouped in an object.
+    if (layer.noneToReveal.length>0) {
+      if (cleanName(randNum[layer.linkLayer].split(':').pop())==='None') {
+        cur_elements = cur_elements['noneToReveal']
+      }
+      else {
+        cur_elements = cur_elements['overlapReveal']
+      }
+    }
+
+    cur_elements.forEach((element) => {
       totalWeight += element.weight;
     });
+    
     // number between 0 - totalWeight
     let random = Math.floor(Math.random() * totalWeight);
-    for (var i = 0; i < layer.elements.length; i++) {
+    for (var i = 0; i < cur_elements.length; i++) {
       // subtract the current weight from the random weight until we reach a sub zero value.
-      random -= layer.elements[i].weight;
+      random -= cur_elements[i].weight;
       if (random < 0) {
         return randNum.push(
-          `${layer.elements[i].id}:${layer.elements[i].filename}${
+          `${cur_elements[i].id}:${cur_elements[i].filename}${
             layer.bypassDNA ? "?bypassDNA=true" : ""
           }`
         );


### PR DESCRIPTION
Two conditional rules of constructing layers to DNA are implemented to adapt the situations as follows:

 1. A layer folder has its sub-folders, each sub-folder contains image files which only apply to a certain trait (image file) of another specified layer, e.g. "Hair" layer has 'White', 'Yellow,' 'Golden' sub-folders, the files for hair-styles inside the 'White' sub-folder can only apply to White fur trait (White.png) of "Fur" layer.
 2. Some of image files for traits in a layer only apply/reveal when the trait of a specified layer is None (None.png blank image file), and the rest apply when the trait of the specified layer is not None.
The src/main.js code was modified together with more 'options' added to layerConfigurations.layersOrder in src/config.js.

This modification does not affect any of the original functions of the main release, hopefully will be merged to the main release.